### PR TITLE
SMP 1268: Remove cpu from resources.limits

### DIFF
--- a/src/dashboards/values.yaml
+++ b/src/dashboards/values.yaml
@@ -115,7 +115,6 @@ ng-custom-dashboards:
 
   resources:
     limits:
-      cpu: 1
       memory: 1536Mi
     requests:
       cpu: 1
@@ -279,7 +278,6 @@ looker:
 
   resources:
     limits:
-      cpu: 4
       # -- minimum of 6GiB recommended
       memory: 8192Mi
     requests:

--- a/src/looker/values.yaml
+++ b/src/looker/values.yaml
@@ -220,7 +220,6 @@ service:
 
 resources:
   limits:
-    cpu: 4
     # -- minimum of 6GiB recommended
     memory: 8192Mi
   requests:

--- a/src/ng-custom-dashboards/values.yaml
+++ b/src/ng-custom-dashboards/values.yaml
@@ -113,7 +113,6 @@ service:
 
 resources:
   limits:
-    cpu: 1
     memory: 1536Mi
   requests:
     cpu: 1


### PR DESCRIPTION
Refer: [SMP 1268: Remove CPU from the resource limits in Kubernetes Manifests](https://harness.atlassian.net/wiki/spaces/~7120205e3981db61bd4dcc8068ae7262d845f7/pages/edit-v2/21404484175)